### PR TITLE
chore: remove gpus configuration from tinfoil-config.yml

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -2,7 +2,6 @@ shim-version: v0.3.18@sha256:7d9f98be78c91ede89f43c948a12d084fae34312effe9395ca7
 cvm-version: 0.6.7
 cpus: 16
 memory: 65536
-gpus: full
 
 containers:
   - name: "doc-upload"


### PR DESCRIPTION
Removed the 'gpus' configuration from the YAML file.