### PR TITLE
Jules/repetition

### DIFF
--- a/router/vlm.go
+++ b/router/vlm.go
@@ -73,8 +73,7 @@ func vlmCall(ctx context.Context, imageB64, prompt string, maxTokens int) (strin
 			}),
 		},
 		MaxTokens:        openai.Int(int64(maxTokens)),
-		FrequencyPenalty: openai.Float(0.5),
-		Temperature:      openai.Float(0.2),
+		FrequencyPenalty: openai.Float(0.3),
 	})
 	if err != nil {
 		return "", fmt.Errorf("vlm: %w", err)

--- a/router/vlm.go
+++ b/router/vlm.go
@@ -72,7 +72,9 @@ func vlmCall(ctx context.Context, imageB64, prompt string, maxTokens int) (strin
 				openai.TextContentPart(prompt),
 			}),
 		},
-		MaxTokens: openai.Int(int64(maxTokens)),
+		MaxTokens:        openai.Int(int64(maxTokens)),
+		FrequencyPenalty: openai.Float(0.5),
+		Temperature:      openai.Float(0.2),
 	})
 	if err != nil {
 		return "", fmt.Errorf("vlm: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Apply a frequency penalty to VLM requests to reduce repeated phrases and improve output variety. Sets `FrequencyPenalty` to `0.3` in `vlmCall` while keeping `MaxTokens` unchanged; no changes required from callers.

<sup>Written for commit 0a48a61a4a9d704b692c5656251357bf56eb4c15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

