### PR TITLE
Jules/metrics

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -90,6 +90,17 @@ func convertPDF(ctx context.Context, data []byte, filename, mode string, extract
 	slog.Info("classified", "file", filename, "pages", nPages,
 		"scanned", len(scannedIdxs), "born_digital", len(textPages), "mode", mode)
 
+	// Record document metrics (coarse-grained for privacy)
+	metricPages.Observe(float64(nPages))
+	metricSize.Observe(float64(len(data)))
+	if len(scannedIdxs) == 0 {
+		metricDocType.WithLabelValues("born_digital").Inc()
+	} else if len(textPages) == 0 {
+		metricDocType.WithLabelValues("scanned").Inc()
+	} else {
+		metricDocType.WithLabelValues("mixed").Inc()
+	}
+
 	switch mode {
 	case "raw":
 		return convertPDFRaw(nPages, textPages)

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -4,9 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/bits"
 	"strings"
 	"time"
 )
+
+// nextPow2 rounds n up to the nearest power of 2.
+// Used for size metrics to prevent document fingerprinting via exact byte counts.
+func nextPow2(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	return 1 << bits.Len(uint(n-1))
+}
 
 type PageResult struct {
 	Page      int    `json:"page"`
@@ -90,9 +100,10 @@ func convertPDF(ctx context.Context, data []byte, filename, mode string, extract
 	slog.Info("classified", "file", filename, "pages", nPages,
 		"scanned", len(scannedIdxs), "born_digital", len(textPages), "mode", mode)
 
-	// Record document metrics (coarse-grained for privacy)
+	// Record document metrics (coarse-grained for privacy).
+	// Size is rounded to next power of 2 to prevent document fingerprinting.
 	metricPages.Observe(float64(nPages))
-	metricSize.Observe(float64(len(data)))
+	metricSize.Observe(float64(nextPow2(len(data))))
 	if len(scannedIdxs) == 0 {
 		metricDocType.WithLabelValues("born_digital").Inc()
 	} else if len(textPages) == 0 {

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -36,10 +36,27 @@ var (
 	metricDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "router_duration_seconds", Buckets: prometheus.ExponentialBuckets(0.01, 2, 14)}, []string{"format", "mode"})
 	metricActive   = prometheus.NewGauge(prometheus.GaugeOpts{Name: "router_active_requests"})
 	metricErrors   = prometheus.NewCounterVec(prometheus.CounterOpts{Name: "router_errors_total"}, []string{"type"})
+
+	// Coarse-grained buckets to prevent document fingerprinting via exact values
+	metricPages = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "router_document_pages",
+		Help:    "Number of pages per document (bucketed)",
+		Buckets: []float64{1, 2, 5, 10, 20, 50, 100, 200},
+	})
+	metricSize = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "router_document_size_bytes",
+		Help:    "Document size in bytes (bucketed)",
+		Buckets: prometheus.ExponentialBuckets(1024, 4, 8), // 1KB, 4KB, 16KB, 64KB, 256KB, 1MB, 4MB, 16MB
+	})
+	metricDocType = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "router_documents_total",
+		Help: "Documents processed by type",
+	}, []string{"doc_type"}) // "born_digital", "scanned", "mixed"
 )
 
 func init() {
-	prometheus.MustRegister(metricReqs, metricDuration, metricActive, metricErrors)
+	prometheus.MustRegister(metricReqs, metricDuration, metricActive, metricErrors,
+		metricPages, metricSize, metricDocType)
 }
 
 func Main() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add privacy-safe document metrics to improve observability of PDF processing in `prometheus`. Tracks page counts, sizes, and document type without exposing exact values.

- **New Features**
  - Added `router_documents_total{doc_type}` with values: "born_digital", "scanned", "mixed".
  - Added `router_document_pages` histogram with buckets: 1, 2, 5, 10, 20, 50, 100, 200.
  - Added `router_document_size_bytes` histogram with buckets: 1KB, 4KB, 16KB, 64KB, 256KB, 1MB, 4MB, 16MB.

- **Bug Fixes**
  - Size metric is rounded up to the next power of 2 before observing to reduce fingerprinting.

<sup>Written for commit 60d985600bdef9ede1b52286f278897785cdd8eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

