### PR TITLE
fix(observability): /health reflects live VLM state; OCR failures fail loudly

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -180,14 +180,31 @@ func convertPDFVLM(ctx context.Context, data []byte, filename string, nPages int
 
 	vlmResults := vlmParallelMixed(ctx, allWork)
 
+	// Every page's OCR is required in vlm mode. If any page fails, fail the
+	// whole request loudly with a non-200 instead of inserting "[OCR failed]"
+	// into the markdown — SDK consumers were ingesting that as valid text.
 	var parts []string
+	var failedPages []int
+	var firstErr error
 	for i := 1; i <= nPages; i++ {
-		if res, ok := vlmResults[i]; ok && res.err == nil {
-			parts = append(parts, res.text)
-		} else {
-			slog.Warn("vlm ocr failed", "page", i)
-			parts = append(parts, "[OCR failed]")
+		res, ok := vlmResults[i]
+		if !ok || res.err != nil {
+			failedPages = append(failedPages, i)
+			if firstErr == nil && ok {
+				firstErr = res.err
+			}
+			parts = append(parts, "")
+			continue
 		}
+		parts = append(parts, res.text)
+	}
+	if len(failedPages) > 0 {
+		slog.Error("vlm ocr failed for required pages",
+			"file", filename, "mode", "vlm",
+			"failed_pages", failedPages, "total_pages", nPages,
+			"first_err", firstErr)
+		return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d/%d pages (first: %v)",
+			len(failedPages), nPages, firstErr)
 	}
 
 	slog.Info("processed", "file", filename, "pages", nPages,
@@ -221,13 +238,27 @@ func convertPDFText(ctx context.Context, data []byte, filename string, nPages in
 
 		if len(vlmWork) > 0 {
 			vlmResults := vlmParallelMixed(ctx, vlmWork)
+			var failedPages []int
+			var firstErr error
 			for idx, res := range vlmResults {
 				if res.err != nil {
-					slog.Warn("vlm ocr failed", "page", idx, "err", res.err)
-					textPages[idx] = "[OCR failed]"
-				} else {
-					textPages[idx] = res.text
+					failedPages = append(failedPages, idx)
+					if firstErr == nil {
+						firstErr = res.err
+					}
+					continue
 				}
+				textPages[idx] = res.text
+			}
+			// Scanned-page OCR is the only path to text for these pages —
+			// failure means we'd ship a silently-broken response. Fail loudly.
+			if len(failedPages) > 0 {
+				slog.Error("vlm ocr failed for scanned pages",
+					"file", filename, "mode", "text",
+					"failed_pages", failedPages, "scanned_pages", len(scannedIdxs),
+					"first_err", firstErr)
+				return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d scanned page(s) (first: %v)",
+					len(failedPages), firstErr)
 			}
 		}
 	}
@@ -273,12 +304,17 @@ func convertPDFVision(ctx context.Context, data []byte, filename string, nPages 
 	vlmResults := vlmParallelMixed(ctx, allVLMWork)
 
 	visualDescs := make(map[int]string)
+	var ocrFailed []int
+	var firstOCRErr error
 	for idx, res := range vlmResults {
 		work := allVLMWork[idx]
 		if res.err != nil {
 			slog.Warn("vlm failed", "page", idx, "kind", work.kind, "err", res.err)
 			if work.kind == "ocr" {
-				textPages[idx] = "[OCR failed]"
+				ocrFailed = append(ocrFailed, idx)
+				if firstOCRErr == nil {
+					firstOCRErr = res.err
+				}
 			}
 			continue
 		}
@@ -290,6 +326,16 @@ func convertPDFVision(ctx context.Context, data []byte, filename string, nPages 
 				visualDescs[idx] = d
 			}
 		}
+	}
+	// OCR for scanned pages is required; visual descriptions for born-digital
+	// pages remain best-effort and don't fail the request.
+	if len(ocrFailed) > 0 {
+		slog.Error("vlm ocr failed for scanned pages",
+			"file", filename, "mode", "vision",
+			"failed_pages", ocrFailed, "scanned_pages", len(scannedIdxs),
+			"first_err", firstOCRErr)
+		return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d scanned page(s) (first: %v)",
+			len(ocrFailed), firstOCRErr)
 	}
 
 	var parts []string

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -62,6 +63,21 @@ func init() {
 func Main() {
 	initTinfoilClient()
 
+	// Seed lastVLMSuccess with a real inference roundtrip so /health
+	// reflects actual upstream connectivity (not just whether NewClient
+	// returned a non-nil pointer). If this fails we still start serving —
+	// /health will return 503 and the watchdog will keep retrying so the
+	// service self-heals when the upstream enclave comes back.
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := vlmProbe(probeCtx); err != nil {
+		slog.Error("VLM startup probe failed; /health will report degraded", "err", err)
+	} else {
+		slog.Info("VLM startup probe succeeded", "model", vlmModel)
+	}
+	probeCancel()
+
+	go vlmWatchdog(context.Background())
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth)
 	mux.Handle("GET /metrics", promhttp.Handler())
@@ -83,16 +99,36 @@ func Main() {
 	}
 }
 
+// handleHealth returns 200 only when every dependency is currently usable.
+//
+// Previously this returned 200 with `"status":"degraded"` in the body, so
+// upstream probes (Betterstack, k8s readiness, load balancer health checks)
+// considered the service healthy even when the VLM was completely
+// unreachable — most probes only key off the HTTP status code. The vlmOK
+// check also used to be a nil-pointer check, which couldn't catch SDK
+// connection loss, failed cert rotation, or stale-enclave conditions.
+//
+// vlmHealthy() reads the timestamp of the last successful inference (real
+// traffic OR background probe), so this endpoint reflects current upstream
+// connectivity within vlmHealthyWindow.
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	sOK := checkHealth(sidecarURL + "/health")
-	vlmOK := tinfoilVLM != nil
+	vlmOK := vlmHealthy()
 	status := "ok"
+	code := http.StatusOK
 	if !sOK || !vlmOK {
 		status = "degraded"
+		code = http.StatusServiceUnavailable
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
-		"status": status, "router": true, "sidecar": sOK, "vlm": vlmOK,
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":     status,
+		"router":     true,
+		"sidecar":    sOK,
+		"vlm":        vlmOK,
+		"vlm_model":  vlmModel,
+		"checked_at": time.Now().UTC().Format(time.RFC3339),
 	})
 }
 

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -17,7 +19,30 @@ var (
 	vlmKey   = envOr("TINFOIL_API_KEY", "")
 
 	tinfoilVLM *tinfoil.Client
+
+	// lastVLMSuccess is the unix-nano timestamp of the most recent successful
+	// VLM round-trip (real call or background probe). vlmHealthy() reads this
+	// to decide if the SDK is currently usable — a non-nil tinfoilVLM pointer
+	// is not sufficient because the SDK can lose its enclave connection,
+	// fail cert rotation, or be pointed at a stale enclave host.
+	lastVLMSuccess atomic.Int64
+
+	// vlmProbeInterval is how often the background watchdog forces a real
+	// inference roundtrip. Keep short enough that Betterstack catches an
+	// outage within ~1 minute.
+	vlmProbeInterval = time.Duration(envInt("VLM_PROBE_INTERVAL_SECONDS", 30)) * time.Second
+
+	// vlmHealthyWindow is the staleness threshold for lastVLMSuccess. If we
+	// haven't seen a successful call (real or probe) in this window, we
+	// report degraded.
+	vlmHealthyWindow = time.Duration(envInt("VLM_HEALTHY_WINDOW_SECONDS", 90)) * time.Second
 )
+
+// 1x1 transparent PNG used by the startup/background probes. We need a real
+// inference roundtrip — not just a TLS dial — so SDK-level failures (lost
+// enclave connection, cert rotation gave up, model rotated to a new enclave
+// we can't reach) actually surface in /health.
+const probePNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 const vlmOCRPrompt = "Convert this page to markdown. Do not miss any text and only output the bare markdown!"
 
@@ -81,6 +106,7 @@ func vlmCall(ctx context.Context, imageB64, prompt string, maxTokens int) (strin
 	if len(resp.Choices) == 0 {
 		return "", fmt.Errorf("vlm: empty response")
 	}
+	lastVLMSuccess.Store(time.Now().UnixNano())
 
 	md := strings.TrimSpace(resp.Choices[0].Message.Content)
 	if strings.HasPrefix(md, "```") {
@@ -188,4 +214,59 @@ func vlmParallelMixed(ctx context.Context, work map[int]vlmWorkItem) map[int]vlm
 	}
 	wg.Wait()
 	return results
+}
+
+// vlmHealthy reports whether the VLM has succeeded recently. It is the
+// canonical signal for /health: a non-nil tinfoilVLM pointer alone is
+// insufficient because the SDK can lose its enclave connection, fail
+// attestation re-verification on cert rotation, or be pointing at a stale
+// enclave host after the model migrated to a new one.
+//
+// "Recent" is defined by vlmHealthyWindow (default 90s). lastVLMSuccess is
+// updated by both real traffic (vlmCall) and the background probe, so an
+// idle service still reports correctly as long as the watchdog is running.
+func vlmHealthy() bool {
+	if tinfoilVLM == nil {
+		return false
+	}
+	last := lastVLMSuccess.Load()
+	if last == 0 {
+		return false
+	}
+	return time.Since(time.Unix(0, last)) <= vlmHealthyWindow
+}
+
+// vlmProbe forces a real inference roundtrip with a 1x1 PNG. Used at
+// startup to seed lastVLMSuccess and by the background watchdog to flip
+// /health to degraded within vlmHealthyWindow when the VLM is broken.
+func vlmProbe(ctx context.Context) error {
+	if tinfoilVLM == nil {
+		return fmt.Errorf("VLM client not initialized")
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	_, err := vlmCall(probeCtx, probePNGBase64, "Reply with the single word OK.", 8)
+	return err
+}
+
+// vlmWatchdog runs forever, probing the VLM at vlmProbeInterval. Failures
+// are logged but never crash the router — when the upstream enclave comes
+// back, /health flips healthy on the next successful probe.
+func vlmWatchdog(ctx context.Context) {
+	if vlmProbeInterval <= 0 {
+		return
+	}
+	t := time.NewTicker(vlmProbeInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		if err := vlmProbe(ctx); err != nil {
+			slog.Warn("vlm probe failed", "err", err,
+				"healthy", vlmHealthy(), "model", vlmModel)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Two surgical fixes so we get a real signal when doc-upload is broken.

### 1. \`/health\` returns 503 when the VLM is actually unreachable

Previously \`/health\` always returned 200 with \`\"status\":\"degraded\"\` in the body when the VLM was down. Upstream probes (Betterstack, k8s readiness, LB health checks) only key off the HTTP status code, so this was invisible to them. The \`vlmOK\` signal was also just a nil-pointer check on \`tinfoilVLM\`, which can't catch:

- SDK connection loss after init
- Failed certificate rotation / re-attestation
- The model rotating to a new enclave host the SDK is no longer pointing at

Now:

- A background watchdog (\`vlmWatchdog\`) runs every \`VLM_PROBE_INTERVAL_SECONDS\` (default 30s) and forces a real 1×1-PNG inference roundtrip.
- Every successful VLM call (real traffic or probe) updates \`lastVLMSuccess\`.
- \`vlmHealthy()\` returns true only if a successful call landed within \`VLM_HEALTHY_WINDOW_SECONDS\` (default 90s) — so the Betterstack probe flips red within ~1 minute of an outage.
- \`handleHealth\` returns **503** when not healthy. Body shape is unchanged for backwards compatibility (\`{\"status\":\"degraded\",\"router\":true,\"sidecar\":...,\"vlm\":false,...}\`).
- A startup probe seeds \`lastVLMSuccess\` so we don't briefly return 200 on a fresh process before any traffic hits the VLM.

### 2. OCR failures fail the request loudly instead of \`[OCR failed]\` in 200

Previously \`convertPDFText\` / \`convertPDFVLM\` / \`convertPDFVision\` injected the literal string \`\"[OCR failed]\"\` into the markdown and returned 200. SDK consumers ingested it as valid extracted text with no signal in error rates.

Now any failed required-OCR page (scanned pages in \`text\`/\`vision\` mode, every page in \`vlm\` mode) returns a non-2xx via the existing \`httpErr(w, 502, \"processing failed\", ...)\` path. Visual descriptions in \`vision\` mode are still best-effort and don't fail the request.

## Out of scope (follow-up PRs)

- VLM call retries with exponential backoff
- Fail-fast (\`os.Exit(1)\`) on startup probe failure
- Tightened parser sandbox (RLIMIT_AS/CPU/FSIZE, NEWPID/NEWNS/NEWIPC, seccomp allowlist)
- Same sandbox model for the Python sidecar
- Structured per-page \`errors\` array in the response body

## Test plan

- [ ] \`go vet ./internal/server/...\` clean (✅ verified locally)
- [ ] Build a new image, deploy to a staging enclave
- [ ] Confirm \`/health\` returns 200 + \`status:ok\` when VLM is reachable
- [ ] Stop the upstream VLM enclave, confirm \`/health\` flips to 503 within ~90s
- [ ] Restart the VLM, confirm \`/health\` returns to 200 within ~30s (next probe)
- [ ] Hit \`POST /v1/convert/file?mode=vlm\` with VLM down, confirm 502 (not 200 with \`[OCR failed]\`)
- [ ] Confirm the Betterstack probe alerts on the 503

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/health` return 503 when the VLM is unreachable, and fail OCR-required conversions with a non-2xx instead of inserting "[OCR failed]". This improves probe accuracy and prevents silently broken responses.

- **Bug Fixes**
  - `/health`: returns 503 when VLM is down. Added watchdog that runs a real inference every `VLM_PROBE_INTERVAL_SECONDS` (default 30s) and updates `lastVLMSuccess`; `vlmHealthy()` reports healthy only within `VLM_HEALTHY_WINDOW_SECONDS` (default 90s). A startup probe seeds health; JSON body shape is unchanged.
  - OCR: required OCR failures now return 502 instead of 200 with "[OCR failed]". Applies to all pages in `vlm` mode and scanned pages in `text`/`vision`; visual descriptions in `vision` remain best-effort. Logs include failed page indexes and the first error.

<sup>Written for commit 4dceca12898fb4da8ea12f4ee912720cec606f6c. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/69?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

