### PR TITLE
fix: health reflect vlm status and add prometheus metrics for vlm errors

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -180,14 +180,22 @@ func convertPDFVLM(ctx context.Context, data []byte, filename string, nPages int
 
 	vlmResults := vlmParallelMixed(ctx, allWork)
 
-	var parts []string
+	parts := make([]string, nPages)
+	var failed []int
+	var firstErr error
 	for i := 1; i <= nPages; i++ {
-		if res, ok := vlmResults[i]; ok && res.err == nil {
-			parts = append(parts, res.text)
-		} else {
-			slog.Warn("vlm ocr failed", "page", i)
-			parts = append(parts, "[OCR failed]")
+		res, ok := vlmResults[i]
+		if !ok || res.err != nil {
+			failed = append(failed, i)
+			if firstErr == nil && ok {
+				firstErr = res.err
+			}
+			continue
 		}
+		parts[i-1] = res.text
+	}
+	if len(failed) > 0 {
+		return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d/%d pages %v: %w", len(failed), nPages, failed, firstErr)
 	}
 
 	slog.Info("processed", "file", filename, "pages", nPages,
@@ -221,13 +229,20 @@ func convertPDFText(ctx context.Context, data []byte, filename string, nPages in
 
 		if len(vlmWork) > 0 {
 			vlmResults := vlmParallelMixed(ctx, vlmWork)
+			var failed []int
+			var firstErr error
 			for idx, res := range vlmResults {
 				if res.err != nil {
-					slog.Warn("vlm ocr failed", "page", idx, "err", res.err)
-					textPages[idx] = "[OCR failed]"
-				} else {
-					textPages[idx] = res.text
+					failed = append(failed, idx)
+					if firstErr == nil {
+						firstErr = res.err
+					}
+					continue
 				}
+				textPages[idx] = res.text
+			}
+			if len(failed) > 0 {
+				return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d scanned page(s) %v: %w", len(failed), failed, firstErr)
 			}
 		}
 	}
@@ -273,12 +288,17 @@ func convertPDFVision(ctx context.Context, data []byte, filename string, nPages 
 	vlmResults := vlmParallelMixed(ctx, allVLMWork)
 
 	visualDescs := make(map[int]string)
+	var ocrFailed []int
+	var firstOCRErr error
 	for idx, res := range vlmResults {
 		work := allVLMWork[idx]
 		if res.err != nil {
 			slog.Warn("vlm failed", "page", idx, "kind", work.kind, "err", res.err)
 			if work.kind == "ocr" {
-				textPages[idx] = "[OCR failed]"
+				ocrFailed = append(ocrFailed, idx)
+				if firstOCRErr == nil {
+					firstOCRErr = res.err
+				}
 			}
 			continue
 		}
@@ -290,6 +310,9 @@ func convertPDFVision(ctx context.Context, data []byte, filename string, nPages 
 				visualDescs[idx] = d
 			}
 		}
+	}
+	if len(ocrFailed) > 0 {
+		return ConvertResult{}, fmt.Errorf("vlm OCR failed for %d scanned page(s) %v: %w", len(ocrFailed), ocrFailed, firstOCRErr)
 	}
 
 	var parts []string

--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -187,8 +187,12 @@ func convertPDFVLM(ctx context.Context, data []byte, filename string, nPages int
 		res, ok := vlmResults[i]
 		if !ok || res.err != nil {
 			failed = append(failed, i)
-			if firstErr == nil && ok {
-				firstErr = res.err
+			if firstErr == nil {
+				if ok {
+					firstErr = res.err
+				} else {
+					firstErr = fmt.Errorf("page %d: missing result", i)
+				}
 			}
 			continue
 		}

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -52,11 +52,32 @@ var (
 		Name: "router_documents_total",
 		Help: "Documents processed by type",
 	}, []string{"doc_type"}) // "born_digital", "scanned", "mixed"
+
+	// VLM observability. result: success|empty|transport|auth|server|client.
+	metricVLMCalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "router_vlm_calls_total",
+		Help: "VLM calls by kind and outcome",
+	}, []string{"kind", "result"})
+	metricVLMDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "router_vlm_duration_seconds",
+		Help:    "VLM call latency by kind",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 12),
+	}, []string{"kind"})
+	metricVLMHealthy = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "router_vlm_healthy",
+		Help: "1 if VLM is currently healthy, 0 otherwise",
+	}, func() float64 {
+		if vlmHealth.Load() {
+			return 1
+		}
+		return 0
+	})
 )
 
 func init() {
 	prometheus.MustRegister(metricReqs, metricDuration, metricActive, metricErrors,
-		metricPages, metricSize, metricDocType)
+		metricPages, metricSize, metricDocType,
+		metricVLMCalls, metricVLMDuration, metricVLMHealthy)
 }
 
 func Main() {
@@ -85,12 +106,13 @@ func Main() {
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	sOK := checkHealth(sidecarURL + "/health")
-	vlmOK := tinfoilVLM != nil
-	status := "ok"
+	vlmOK := vlmHealthy()
+	status, code := "ok", http.StatusOK
 	if !sOK || !vlmOK {
-		status = "degraded"
+		status, code = "degraded", http.StatusServiceUnavailable
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
 	json.NewEncoder(w).Encode(map[string]any{
 		"status": status, "router": true, "sidecar": sOK, "vlm": vlmOK,
 	})

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -17,7 +21,11 @@ var (
 	vlmKey   = envOr("TINFOIL_API_KEY", "")
 
 	tinfoilVLM *tinfoil.Client
+	// Tracks live VLM connectivity. Seeded true when the connection succeeds.
+	vlmHealth atomic.Bool
 )
+
+func vlmHealthy() bool { return vlmHealth.Load() }
 
 const vlmOCRPrompt = "Convert this page to markdown. Do not miss any text and only output the bare markdown!"
 
@@ -55,13 +63,16 @@ func initTinfoilClient() {
 		return
 	}
 	tinfoilVLM = client
+	vlmHealth.Store(true)
 	slog.Info("tinfoil VLM client initialized", "model", vlmModel)
 }
 
-func vlmCall(ctx context.Context, imageB64, prompt string, maxTokens int) (string, error) {
+func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) (string, error) {
 	if tinfoilVLM == nil {
+		metricVLMCalls.WithLabelValues(kind, "transport").Inc()
 		return "", fmt.Errorf("VLM client not initialized (missing TINFOIL_API_KEY?)")
 	}
+	t0 := time.Now()
 	resp, err := tinfoilVLM.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Model: vlmModel,
 		Messages: []openai.ChatCompletionMessageParamUnion{
@@ -75,12 +86,36 @@ func vlmCall(ctx context.Context, imageB64, prompt string, maxTokens int) (strin
 		MaxTokens:        openai.Int(int64(maxTokens)),
 		FrequencyPenalty: openai.Float(0.3),
 	})
+	metricVLMDuration.WithLabelValues(kind).Observe(time.Since(t0).Seconds())
 	if err != nil {
+		// Classify once: feeds both the prom counter and the health flip.
+		// "client" (other 4xx) leaves health untouched — request itself
+		// was bad; service is up.
+		var apiErr *openai.Error
+		var result string
+		switch {
+		case !errors.As(err, &apiErr):
+			result = "transport"
+		case apiErr.StatusCode == http.StatusUnauthorized,
+			apiErr.StatusCode == http.StatusForbidden:
+			result = "auth"
+		case apiErr.StatusCode >= 500:
+			result = "server"
+		default:
+			result = "client"
+		}
+		metricVLMCalls.WithLabelValues(kind, result).Inc()
+		if result != "client" {
+			vlmHealth.Store(false)
+		}
 		return "", fmt.Errorf("vlm: %w", err)
 	}
+	vlmHealth.Store(true)
 	if len(resp.Choices) == 0 {
+		metricVLMCalls.WithLabelValues(kind, "empty").Inc()
 		return "", fmt.Errorf("vlm: empty response")
 	}
+	metricVLMCalls.WithLabelValues(kind, "success").Inc()
 
 	md := strings.TrimSpace(resp.Choices[0].Message.Content)
 	if strings.HasPrefix(md, "```") {
@@ -140,11 +175,11 @@ func truncateRepetition(s string) string {
 }
 
 func vlmFullPageOCR(ctx context.Context, imageB64 string) (string, error) {
-	return vlmCall(ctx, imageB64, vlmOCRPrompt, 8000)
+	return vlmCall(ctx, "ocr", imageB64, vlmOCRPrompt, 8000)
 }
 
 func vlmVisualExtract(ctx context.Context, imageB64 string) (string, error) {
-	return vlmCall(ctx, imageB64, vlmVisualPrompt, 4000)
+	return vlmCall(ctx, "vision", imageB64, vlmVisualPrompt, 4000)
 }
 
 type vlmPageFunc func(ctx context.Context, imageB64 string) (string, error)

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -89,11 +89,14 @@ func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) 
 	metricVLMDuration.WithLabelValues(kind).Observe(time.Since(t0).Seconds())
 	if err != nil {
 		// Classify once: feeds both the prom counter and the health flip.
-		// "client" (other 4xx) leaves health untouched — request itself
-		// was bad; service is up.
+		// "client" (other 4xx) and "canceled" (caller-driven ctx errors)
+		// leave health untouched — the service itself isn't necessarily
+		// at fault.
 		var apiErr *openai.Error
 		var result string
 		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			result = "canceled"
 		case !errors.As(err, &apiErr):
 			result = "transport"
 		case apiErr.StatusCode == http.StatusUnauthorized,
@@ -105,7 +108,8 @@ func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) 
 			result = "client"
 		}
 		metricVLMCalls.WithLabelValues(kind, result).Inc()
-		if result != "client" {
+		switch result {
+		case "transport", "auth", "server":
 			vlmHealth.Store(false)
 		}
 		return "", fmt.Errorf("vlm: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Health now reflects VLM status and returns 503 when degraded. Added Prometheus metrics for VLM outcomes/latency, and OCR failures now fail the conversion with a wrapped error instead of inserting placeholders.

- **New Features**
  - `/health` reports VLM status and returns 503 when sidecar or VLM is unhealthy.
  - Prometheus: `router_vlm_calls_total` (labels: kind, result), `router_vlm_duration_seconds` (by kind), `router_vlm_healthy` gauge.
  - VLM calls labeled by kind; health flips to unhealthy on transport/auth/5xx; conversion errors list failed pages and include the first underlying VLM error.

- **Migration**
  - Update alerts/checks to expect 503 from `/health` when VLM is down or degraded.
  - Handle conversion errors for scanned pages where OCR fails (no more “[OCR failed]” placeholders).

<sup>Written for commit 01c0ec1cc173649e034ad7cb65854475f4ef0bf9. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/70?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

