### PR TITLE
fix: add retry logic for Tinfoil client

### DIFF
--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -72,12 +72,16 @@ var (
 		}
 		return 0
 	})
+	metricVLMReinits = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "router_vlm_reinits_total",
+		Help: "Tinfoil SDK re-init attempts after persistent unhealth",
+	}, []string{"result"}) // success | error
 )
 
 func init() {
 	prometheus.MustRegister(metricReqs, metricDuration, metricActive, metricErrors,
 		metricPages, metricSize, metricDocType,
-		metricVLMCalls, metricVLMDuration, metricVLMHealthy)
+		metricVLMCalls, metricVLMDuration, metricVLMHealthy, metricVLMReinits)
 }
 
 func Main() {

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -20,12 +20,54 @@ var (
 	vlmModel = envOr("VLM_MODEL", "gemma4-31b")
 	vlmKey   = envOr("TINFOIL_API_KEY", "")
 
-	tinfoilVLM *tinfoil.Client
+	tinfoilVLM atomic.Pointer[tinfoil.Client]
 	// Tracks live VLM connectivity. Seeded true when the connection succeeds.
 	vlmHealth atomic.Bool
+	// unhealthySince (unix-nanos) is set when health flips from true→false,
+	// cleared on success. maybeReinitClient() uses it to decide when to ask
+	// the SDK to reconnect from scratch (handles enclave host rotation, etc).
+	unhealthySince atomic.Int64
+	reinitMu       sync.Mutex
 )
 
+const vlmReinitAfter = 5 * time.Minute
+
 func vlmHealthy() bool { return vlmHealth.Load() }
+
+func setVLMHealth(ok bool) {
+	vlmHealth.Store(ok)
+	if ok {
+		unhealthySince.Store(0)
+	} else {
+		unhealthySince.CompareAndSwap(0, time.Now().UnixNano())
+	}
+}
+
+// maybeReinitClient asks the tinfoil SDK to reconnect from scratch when the
+// VLM has been unhealthy for vlmReinitAfter.
+func maybeReinitClient() {
+	since := unhealthySince.Load()
+	if since == 0 || time.Since(time.Unix(0, since)) < vlmReinitAfter {
+		return
+	}
+	if !reinitMu.TryLock() {
+		return
+	}
+	defer reinitMu.Unlock()
+	if unhealthySince.Load() == 0 {
+		return
+	}
+	client, err := tinfoil.NewClient(option.WithAPIKey(vlmKey))
+	if err != nil {
+		metricVLMReinits.WithLabelValues("error").Inc()
+		slog.Warn("tinfoil re-init failed", "err", err)
+		unhealthySince.Store(time.Now().UnixNano())
+		return
+	}
+	tinfoilVLM.Store(client)
+	metricVLMReinits.WithLabelValues("success").Inc()
+	slog.Info("tinfoil client re-initialized", "enclave", client.Enclave())
+}
 
 const vlmOCRPrompt = "Convert this page to markdown. Do not miss any text and only output the bare markdown!"
 
@@ -62,18 +104,20 @@ func initTinfoilClient() {
 		slog.Error("failed to create Tinfoil client", "err", err)
 		return
 	}
-	tinfoilVLM = client
-	vlmHealth.Store(true)
+	tinfoilVLM.Store(client)
+	setVLMHealth(true)
 	slog.Info("tinfoil VLM client initialized", "model", vlmModel)
 }
 
 func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) (string, error) {
-	if tinfoilVLM == nil {
+	maybeReinitClient()
+	client := tinfoilVLM.Load()
+	if client == nil {
 		metricVLMCalls.WithLabelValues(kind, "transport").Inc()
 		return "", fmt.Errorf("VLM client not initialized (missing TINFOIL_API_KEY?)")
 	}
 	t0 := time.Now()
-	resp, err := tinfoilVLM.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+	resp, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 		Model: vlmModel,
 		Messages: []openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage([]openai.ChatCompletionContentPartUnionParam{
@@ -114,7 +158,7 @@ func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) 
 		}
 		return "", fmt.Errorf("vlm: %w", err)
 	}
-	vlmHealth.Store(true)
+	setVLMHealth(true)
 	if len(resp.Choices) == 0 {
 		metricVLMCalls.WithLabelValues(kind, "empty").Inc()
 		return "", fmt.Errorf("vlm: empty response")

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -61,7 +61,10 @@ func maybeReinitClient() {
 	if err != nil {
 		metricVLMReinits.WithLabelValues("error").Inc()
 		slog.Warn("tinfoil re-init failed", "err", err)
-		unhealthySince.Store(time.Now().UnixNano())
+		// Push the backoff clock forward only if we're still unhealthy.
+		if !vlmHealth.Load() {
+			unhealthySince.Store(time.Now().UnixNano())
+		}
 		return
 	}
 	tinfoilVLM.Store(client)

--- a/internal/server/vlm.go
+++ b/internal/server/vlm.go
@@ -154,7 +154,7 @@ func vlmCall(ctx context.Context, kind, imageB64, prompt string, maxTokens int) 
 		metricVLMCalls.WithLabelValues(kind, result).Inc()
 		switch result {
 		case "transport", "auth", "server":
-			vlmHealth.Store(false)
+			setVLMHealth(false)
 		}
 		return "", fmt.Errorf("vlm: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds automatic re-init and retry logic for the `tinfoil` VLM client to recover from persistent unhealth and enclave rotations. Adds a `prometheus` counter to track re-init attempts and fixes a race condition in client access.

- **Bug Fixes**
  - Re-initialize the `tinfoil` client after 5 minutes of continuous unhealth via `maybeReinitClient()`, called before each `vlmCall`.
  - Fix race conditions: store the client in an `atomic.Pointer`, load per call, and guard re-inits with a `TryLock` mutex; route all health updates through `setVLMHealth` with `unhealthySince` tracking.
  - Expose and register `router_vlm_reinits_total{result}` (`success`/`error`) with `prometheus`.

<sup>Written for commit 08f6eb0d0b674b350559c194d4ad92785c833732. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/71?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

