### PR TITLE
feat: add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN CGO_ENABLED=1 go build -o /app/bin/pdfparser -ldflags="-s -w" ./cmd/pdfparse
 # Stage 3: Runtime with minimal Python sidecar for non-PDF formats
 FROM python:3.12-alpine
 
+RUN apk add --no-cache curl
+
 RUN pip install --no-cache-dir \
     python-docx \
     python-pptx \

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -5,6 +5,7 @@ memory: 16384
 containers:
   - name: "doc-upload"
     image: "ghcr.io/tinfoilsh/confidential-doc-upload@sha256:abdac072274712f82c34931f5f549736e86f56264c65727f8d3486791f393bdb" # v0.0.29
+    restart: always
     cap_add:
       - SYS_ADMIN
     env:
@@ -14,6 +15,11 @@ containers:
       - MAX_PARALLEL: "32"
     secrets:
       - TINFOIL_API_KEY
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 5m
 
 shim:
   upstream-port: 5000


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a HTTP healthcheck for the doc-upload container and enable automatic restarts. Installs `curl` so the health probe can run in the runtime image.

- **New Features**
  - Healthcheck: curl -sf http://localhost:5000/health every 30s (5s timeout, 5m start period).
  - Set `restart: always` to auto-restart on failures.

- **Dependencies**
  - Install `curl` in the Python runtime image for the healthcheck.

<sup>Written for commit 8f6724a2c4aaf529cdef601bc687562fd8d46942. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/73?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

