### PR TITLE
fix: add text per page in image mode

### DIFF
--- a/internal/server/convert.go
+++ b/internal/server/convert.go
@@ -20,6 +20,7 @@ func nextPow2(n int) int {
 
 type PageResult struct {
 	Page      int    `json:"page"`
+	Text      string `json:"text,omitempty"`
 	Image     string `json:"image,omitempty"`
 	IsScanned bool   `json:"is_scanned"`
 }
@@ -144,6 +145,7 @@ func convertPDFImages(ctx context.Context, data []byte, filename string, nPages 
 		parts = append(parts, textPages[i])
 		pages = append(pages, PageResult{
 			Page:      i,
+			Text:      textPages[i],
 			Image:     renderedMap[i],
 			IsScanned: scannedSet[i],
 		})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add per-page text to image‑mode PDF conversion outputs by including a new `text` field in the response and populating it from `textPages`. Clients can now access extracted/OCR text alongside each image.

<sup>Written for commit 3d70de9f06f61e4b103d15a85fda4732cb885f0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

