### PR TITLE
Bump cvmimage to 0.10.2

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,10 +1,11 @@
-cvm-version: 0.7.5
+cvm-version: 0.10.2
 cpus: 8
 memory: 16384
 
 containers:
   - name: "doc-upload"
     image: "ghcr.io/tinfoilsh/confidential-doc-upload@sha256:0000000000000000000000000000000000000000000000000000000000000000" # placeholder - populated during release
+    networks: ["egress"]
     restart: always
     cap_add:
       - SYS_ADMIN
@@ -20,6 +21,12 @@ containers:
       interval: 30s
       timeout: 5s
       start_period: 5m
+    tmpfs:
+      /tmp: size=512m,mode=1777,exec
+
+networks:
+  egress:
+    egress: open
 
 shim:
   upstream-port: 5000


### PR DESCRIPTION
Summary:
- Bump cvmimage to 0.10.2.
- Add explicit open egress for VLM calls.
- Add writable /tmp tmpfs for the sandboxed parser path under the new read-only default.

Tests:
- go test ./... attempted; local macOS build lacks MuPDF headers and Linux-only CLONE_NEWNET support.
- YAML parse and network-reference validation across the router model repo batch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `cvmimage` to 0.10.2 and update the sandbox config so VLM calls and parsing work under the new read-only default. Adds an explicit `egress` network for outbound calls and a writable `/tmp` tmpfs (512MB, exec) for the parser.

<sup>Written for commit 1fcbaee278b605c7a85b6469d548c6a37055f575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

