### PR TITLE
chore: update config for cvm v0.10.4

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,4 +1,4 @@
-cvm-version: 0.7.5
+cvm-version: 0.10.4
 cpus: 8
 memory: 16384
 
@@ -6,6 +6,7 @@ containers:
   - name: "doc-upload"
     image: "ghcr.io/tinfoilsh/confidential-doc-upload@sha256:0000000000000000000000000000000000000000000000000000000000000000" # placeholder - populated during release
     restart: always
+    networks: [web]
     cap_add:
       - SYS_ADMIN
     env:
@@ -20,6 +21,10 @@ containers:
       interval: 30s
       timeout: 5s
       start_period: 5m
+
+networks:
+  web:
+    egress: open
 
 shim:
   upstream-port: 5000


### PR DESCRIPTION
Bump cvm-version to 0.10.4 and add web egress for inf14-validated CPU enclave configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `tinfoil-config.yml` to use `cvm-version` 0.10.4 and enable open web egress for the CPU enclave. Adds a `web` network and attaches the `doc-upload` container to it to meet INF-14 validation.

<sup>Written for commit b76343dccf6e12ecc74838953dd3aba057fbde2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

