### PR TITLE
Require auth for /metrics

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -31,6 +31,7 @@ shim:
   authenticated: true
   authenticated-endpoints:
     - /v1/convert/file
+    - /metrics
   paths:
     - /health
     - /metrics


### PR DESCRIPTION
Adds /metrics to the shim's authenticated endpoints so vLLM metrics are no longer publicly scrapeable; Prometheus and the router's overload poller authenticate with an admin key. Deploy after tinfoilsh/controlplane#499 — the current validate-key would reject the admin key and break scraping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down `/metrics` by making it an authenticated endpoint in the shim. vLLM metrics are no longer publicly scrapeable; scrapers must send an admin key.

- **Migration**
  - Deploy after `tinfoilsh/controlplane#499` so admin keys pass validation.
  - Confirm Prometheus and the router’s overload poller send the admin key when scraping `/metrics`.

<sup>Written for commit 717bc72cbf6a1e91053529b811cd319e32642ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/confidential-doc-upload/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

